### PR TITLE
Add Logging

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -10,7 +10,9 @@ logger = logging.getLogger("app")
 
 
 def setup_logging(log_level):
-    formatter = logging.Formatter('%(asctime)s %(levelname)s: %(message)s', "%Y-%m-%d %H:%M:%S")
+    formatter = logging.Formatter(
+        "%(asctime)s %(levelname)s: %(message)s", "%Y-%m-%d %H:%M:%S"
+    )
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)
     logger.addHandler(handler)
@@ -34,11 +36,15 @@ def load_extensions(bot, extensions):
 
 @click.command()
 @click.option("--token", default=None, help="Token from the developer portal")
-@click.option("--log-level", default="INFO", type=click.Choice(['INFO', 'DEBUG', 'WARNING', 'ERROR'], case_sensitive=False))
+@click.option(
+    "--log-level",
+    default="INFO",
+    type=click.Choice(["INFO", "DEBUG", "WARNING", "ERROR"], case_sensitive=False),
+)
 def main(token, log_level):
     setup_logging(log_level)
 
-    logger.info('Setting up bot')
+    logger.info("Setting up bot")
     bot = commands.Bot(command_prefix="!")
 
     @bot.event

--- a/bot.py
+++ b/bot.py
@@ -2,6 +2,19 @@ import discord
 from discord.ext import commands
 import os
 import click
+import logging
+import sys
+
+
+logger = logging.getLogger("app")
+
+
+def setup_logging(log_level):
+    formatter = logging.Formatter('%(asctime)s %(levelname)s: %(message)s', "%Y-%m-%d %H:%M:%S")
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(getattr(logging, log_level))
 
 
 def load_extensions(bot, extensions):
@@ -14,21 +27,25 @@ def load_extensions(bot, extensions):
     for extension in extensions:
         try:
             bot.load_extension(extension)
-            print(f"Extension {extension} loaded")
+            logger.debug(f"Extension {extension} loaded")
         except Exception as error:
-            print(f"{error}")
+            logger.debug(f"{error}")
 
 
 @click.command()
 @click.option("--token", default=None, help="Token from the developer portal")
-def main(token):
+@click.option("--log-level", default="INFO", type=click.Choice(['INFO', 'DEBUG', 'WARNING', 'ERROR'], case_sensitive=False))
+def main(token, log_level):
+    setup_logging(log_level)
+
+    logger.info('Setting up bot')
     bot = commands.Bot(command_prefix="!")
 
     @bot.event
     async def on_ready():
         """Change bot display message once online"""
         await bot.change_presence(activity=discord.Game(name="!help"))
-        print("Bot online")
+        logger.info("Bot online")
 
     extensions = ["cogs.stats_commands"]
     load_extensions(bot, extensions)

--- a/cogs/stats_commands.py
+++ b/cogs/stats_commands.py
@@ -13,7 +13,6 @@ class Stats(commands.Cog):
     Attributes:
         bot (Bot): instance of the bot the cog will attach to
     """
-
     def __init__(self, bot):
         """Initialization method
 
@@ -45,9 +44,7 @@ class Stats(commands.Cog):
     @commands.command()
     async def getMatchdayResults(self, ctx, matchday, season):
         results = get_matchday_results(matchday, season)
-
         embed = embedded_matchday_results(matchday, results)
-
         await ctx.send(embed=embed)
 
 

--- a/cogs/stats_commands.py
+++ b/cogs/stats_commands.py
@@ -13,6 +13,7 @@ class Stats(commands.Cog):
     Attributes:
         bot (Bot): instance of the bot the cog will attach to
     """
+
     def __init__(self, bot):
         """Initialization method
 

--- a/the_mines/download/get_html.py
+++ b/the_mines/download/get_html.py
@@ -21,7 +21,7 @@ def download_html(matchday, season):
         data str containing downloaded html page content
     """
     try:
-        logger.debug('Downloading data file')
+        logger.debug("Downloading data file")
         url = "https://www.fussballdaten.de/bundesliga/" + season[5:9] + "/" + matchday
         data = str(requests.get(url).content)
 

--- a/the_mines/download/get_html.py
+++ b/the_mines/download/get_html.py
@@ -1,4 +1,8 @@
 import requests
+import logging
+
+
+logger = logging.getLogger("app")
 
 
 def download_html(matchday, season):
@@ -17,10 +21,11 @@ def download_html(matchday, season):
         data str containing downloaded html page content
     """
     try:
+        logger.debug('Downloading data file')
         url = "https://www.fussballdaten.de/bundesliga/" + season[5:9] + "/" + matchday
         data = str(requests.get(url).content)
 
     except Exception:
-        print(f"Unable to download file using params: {matchday}, {season}")
+        logger.debug(f"Unable to download file using params: {matchday}, {season}")
 
     return data


### PR DESCRIPTION
# Description
- Replaces print statements with logger to `stdout`

Ex.
```bash
(venv)$ python bot.py --log-level debug
2020-06-01 21:49:09 INFO: Setting up bot
2020-06-01 21:49:09 DEBUG: Extension cogs.stats_commands loaded
2020-06-01 21:49:12 INFO: Bot online
```

Resolves #9 

## Special Notes
When adding loggers in different modules we don't need to create a new one.  If the `.getlogger()` is given a name of a logger it already has that logger is used. See `get_html.py` for an example of this.  I think we want to add more logging messages throughout the project (maybe in a different backlog issue), for now I think it is fine.

## Expected Version Bump
- [ ] Major
- [ ] Minor
- [x] Patch
- [ ] None

# Checklist:
- [x] I have run `black .`
- [ ] I have made corresponding changes to the documentation (n/a)
- [ ] I have added tests that prove my fix is effective or that my feature works (n/a)
