### PR TITLE
Clean up command after call

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -38,7 +38,7 @@ def load_extensions(bot, extensions):
 @click.option("--token", default=None, help="Token from the developer portal")
 @click.option(
     "--log-level",
-    default="DEBUG",
+    default="INFO",
     type=click.Choice(["INFO", "DEBUG", "WARNING", "ERROR"], case_sensitive=False),
 )
 def main(token, log_level):

--- a/cogs/stats_commands.py
+++ b/cogs/stats_commands.py
@@ -37,7 +37,8 @@ class Stats(commands.Cog):
             ctx (Context): command usage context
             player_name (str): name of the player
         """
-        await ctx.message.delete()
+        if logger.level == getattr(logging, "INFO"):
+            await ctx.message.delete()
 
         height, weight, position, gp, goals, assists = get_dummy_data()
         embed = embedded_stats(
@@ -55,7 +56,8 @@ class Stats(commands.Cog):
     async def matchday(
         self, ctx, matchday=get_default_matchday(), season=get_default_season()
     ):
-        await ctx.message.delete()
+        if logger.level == getattr(logging, "INFO"):
+            await ctx.message.delete()
 
         results = process_results(matchday, season)
         for key in results:
@@ -70,7 +72,8 @@ class Stats(commands.Cog):
             ctx (Context): command usage context
             team (str): name of the team
         """
-        await ctx.message.delete()
+        if logger.level == getattr(logging, "INFO"):
+            await ctx.message.delete()
 
         blurb = get_blurb(team)
         blurb.update(get_author_info(ctx))

--- a/cogs/stats_commands.py
+++ b/cogs/stats_commands.py
@@ -38,7 +38,7 @@ class Stats(commands.Cog):
             player_name (str): name of the player
         """
         await ctx.message.delete()
-        
+
         height, weight, position, gp, goals, assists = get_dummy_data()
         embed = embedded_stats(
             player_name,

--- a/cogs/stats_commands.py
+++ b/cogs/stats_commands.py
@@ -37,6 +37,8 @@ class Stats(commands.Cog):
             ctx (Context): command usage context
             player_name (str): name of the player
         """
+        await ctx.message.delete()
+        
         height, weight, position, gp, goals, assists = get_dummy_data()
         embed = embedded_stats(
             player_name,
@@ -53,6 +55,8 @@ class Stats(commands.Cog):
     async def matchday(
         self, ctx, matchday=get_default_matchday(), season=get_default_season()
     ):
+        await ctx.message.delete()
+
         results = process_results(matchday, season)
         for key in results:
             embed = embedded_matchday_results(matchday, season, results, key)
@@ -66,6 +70,8 @@ class Stats(commands.Cog):
             ctx (Context): command usage context
             team (str): name of the team
         """
+        await ctx.message.delete()
+
         blurb = get_blurb(team)
         blurb.update(get_author_info(ctx))
         embed = dict_to_embed(blurb)

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -116,6 +116,6 @@ def get_default_season():
 
         title = soup.title.text
         ind = title.index("/")
-        opening, closing = title[ind - 4 : ind + 5].strip().split('/')
+        opening, closing = title[ind - 4 : ind + 5].strip().split("/")
 
     return closing


### PR DESCRIPTION
# Description
- Add message deletion

Resolves #32 

## Special Notes
Thanks to the `discord.py` rewrite this was much simpler than it [used to be](https://github.com/nikola-rados/Bentley/blob/master/cogs/motions.py#L30).  There is no need for use to factor our the process since it is already as simple as calling the built in method.

We may want to think about better error handling.  As of right now the bot crashes and tells us in the terminal, but a user would have no idea why the bot isn't replying.  Removing the original command exasperates this issue since the user will not know what they did wrong.  We should have `underscore` output a message when an error is thrown. Furthermore, we should consider providing better context in the embedded outputs.  There is a `description` parameter, where we could provide some info on the command (just a thought, this would probably get handled in the embed standardization).

## Suggested Version Bump
- [ ] Major
- [ ] Minor
- [x] Patch

# Checklist:
- [x] I have run `black .`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added logging
