### PR TITLE
i29 help page

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -46,6 +46,7 @@ def main(token, log_level):
 
     logger.info("Setting up bot")
     bot = commands.Bot(command_prefix="!")
+    bot.remove_command('help') # required to use custom help command
 
     @bot.event
     async def on_ready():

--- a/bot.py
+++ b/bot.py
@@ -46,7 +46,7 @@ def main(token, log_level):
 
     logger.info("Setting up bot")
     bot = commands.Bot(command_prefix="!")
-    bot.remove_command('help') # required to use custom help command
+    bot.remove_command("help")  # required to use custom help command
 
     @bot.event
     async def on_ready():

--- a/cogs/stats_commands.py
+++ b/cogs/stats_commands.py
@@ -5,7 +5,12 @@ import logging
 import inspect
 from optparse import OptionParser
 
-from utils.messages import embedded_stats, embedded_matchday_results, help_title_card, embedded_help_command
+from utils.messages import (
+    embedded_stats,
+    embedded_matchday_results,
+    help_title_card,
+    embedded_help_command,
+)
 from utils.embedder import dict_to_embed
 from utils.dummy_data import get_dummy_data
 from utils.misc import get_author_info, get_default_matchday, get_default_season
@@ -32,7 +37,7 @@ class Stats(commands.Cog):
 
         self.bot = bot
 
-    @commands.command(name='help')
+    @commands.command(name="help")
     async def help(self, ctx):
         """
             command.usage is a list containing one tuple for every command argument
@@ -42,14 +47,13 @@ class Stats(commands.Cog):
         embed = help_title_card()
         await ctx.send(embed=embed)
         for command in self.bot.commands:
-            if command.name != 'help':
+            if command.name != "help":
                 embed = embedded_help_command(command)
                 await ctx.send(embed=embed)
 
-
     @commands.command(
-        description='Returns the statistics for given player',
-        usage=[('player_name', 'name of the player')]
+        description="Returns the statistics for given player",
+        usage=[("player_name", "name of the player")],
     )
     async def getStats(self, ctx, player_name):
         """Returns the statistics for given player
@@ -74,8 +78,11 @@ class Stats(commands.Cog):
         await ctx.send(embed=embed)
 
     @commands.command(
-        description='Returns match scores for all matches on a specific matchday. Default is current matchday.',
-        usage=[('matchday', 'A number representing the matchday to lookup (eg. \'23\')'), ('season', 'Specify a season (eg. 2011/2012). Default is current season.')]
+        description="Returns match scores for all matches on a specific matchday. Default is current matchday.",
+        usage=[
+            ("matchday", "A number representing the matchday to lookup (eg. '23')"),
+            ("season", "Specify a season (eg. 2011/2012). Default is current season."),
+        ],
     )
     async def matchday(
         self, ctx, matchday=get_default_matchday(), season=get_default_season()
@@ -95,9 +102,9 @@ class Stats(commands.Cog):
             await ctx.send(embed=embed)
 
     @commands.command(
-        name='blurb',
-        description='Displays an \'at a glance\' view of a teams season',
-        usage=[('team', 'name of the team')]
+        name="blurb",
+        description="Displays an 'at a glance' view of a teams season",
+        usage=[("team", "name of the team")],
     )
     async def blurb(self, ctx, team):
         """Displays an 'at a glance' view of a teams season

--- a/cogs/stats_commands.py
+++ b/cogs/stats_commands.py
@@ -36,7 +36,7 @@ class Stats(commands.Cog):
     async def help(self, ctx):
         """
             command.usage is a list containing one tuple for every command argument
-                eg. usage=[('arg (type)', 'description')]
+                eg. usage=[('arg', 'description')]
         """
 
         embed = help_title_card()
@@ -49,7 +49,7 @@ class Stats(commands.Cog):
 
     @commands.command(
         description='Returns the statistics for given player',
-        usage=[('player_name (str)', 'name of the player')]
+        usage=[('player_name', 'name of the player')]
     )
     async def getStats(self, ctx, player_name):
         """Returns the statistics for given player
@@ -75,7 +75,7 @@ class Stats(commands.Cog):
 
     @commands.command(
         description='Returns match scores for all matches on a specific matchday. Default is current matchday.',
-        usage=[('matchday (str)', 'A number representing the matchday to lookup (eg. \'23\')'), ('season (str)', 'Specify a season (eg. 2011/2012). Default is current season.')]
+        usage=[('matchday', 'A number representing the matchday to lookup (eg. \'23\')'), ('season', 'Specify a season (eg. 2011/2012). Default is current season.')]
     )
     async def matchday(
         self, ctx, matchday=get_default_matchday(), season=get_default_season()
@@ -83,8 +83,8 @@ class Stats(commands.Cog):
         """Returns match scores for all matches on a specific matchday. Default is current matchday.
 
         Args:
-            matchday (str): a number representing the matchday to lookup (eg. '23')
-            season (str): the latter year of the years relating to the season (eg. '2020' for the 2019/2020 season)
+            matchday: a number representing the matchday to lookup (eg. '23')
+            season: the latter year of the years relating to the season (eg. '2020' for the 2019/2020 season)
         """
         if logger.level == getattr(logging, "INFO"):
             await ctx.message.delete()
@@ -97,7 +97,7 @@ class Stats(commands.Cog):
     @commands.command(
         name='blurb',
         description='Displays an \'at a glance\' view of a teams season',
-        usage=[('team (str)', 'name of the team')]
+        usage=[('team', 'name of the team')]
     )
     async def blurb(self, ctx, team):
         """Displays an 'at a glance' view of a teams season

--- a/cogs/stats_commands.py
+++ b/cogs/stats_commands.py
@@ -2,8 +2,10 @@ import discord
 from discord.ext import commands
 from random import choice, randrange
 import logging
+import inspect
+from optparse import OptionParser
 
-from utils.messages import embedded_stats, embedded_matchday_results
+from utils.messages import embedded_stats, embedded_matchday_results, help_title_card, embedded_help_command
 from utils.embedder import dict_to_embed
 from utils.dummy_data import get_dummy_data
 from utils.misc import get_author_info, get_default_matchday, get_default_season
@@ -27,9 +29,28 @@ class Stats(commands.Cog):
         Args:
             bot (Bot): bot to attach to
         """
+
         self.bot = bot
 
-    @commands.command()
+    @commands.command(name='help')
+    async def help(self, ctx):
+        """
+            command.usage is a list containing one tuple for every command argument
+                eg. usage=[('arg (type)', 'description')]
+        """
+
+        embed = help_title_card()
+        await ctx.send(embed=embed)
+        for command in self.bot.commands:
+            if command.name != 'help':
+                embed = embedded_help_command(command)
+                await ctx.send(embed=embed)
+
+
+    @commands.command(
+        description='Returns the statistics for given player',
+        usage=[('player_name (str)', 'name of the player')]
+    )
     async def getStats(self, ctx, player_name):
         """Returns the statistics for given player
 
@@ -52,7 +73,10 @@ class Stats(commands.Cog):
         )
         await ctx.send(embed=embed)
 
-    @commands.command()
+    @commands.command(
+        description='Returns match scores for all matches on a specific matchday. Default is current matchday.',
+        usage=[('matchday (str)', 'A number representing the matchday to lookup (eg. \'23\')'), ('season (str)', 'Specify a season (eg. 2011/2012). Default is current season.')]
+    )
     async def matchday(
         self, ctx, matchday=get_default_matchday(), season=get_default_season()
     ):
@@ -70,7 +94,11 @@ class Stats(commands.Cog):
             embed = embedded_matchday_results(matchday, season, results, key)
             await ctx.send(embed=embed)
 
-    @commands.command()
+    @commands.command(
+        name='blurb',
+        description='Displays an \'at a glance\' view of a teams season',
+        usage=[('team (str)', 'name of the team')]
+    )
     async def blurb(self, ctx, team):
         """Displays an 'at a glance' view of a teams season
 

--- a/cogs/stats_commands.py
+++ b/cogs/stats_commands.py
@@ -2,8 +2,6 @@ import discord
 from discord.ext import commands
 from random import choice, randrange
 import logging
-import inspect
-from optparse import OptionParser
 
 from utils.messages import (
     embedded_stats,

--- a/utils/messages.py
+++ b/utils/messages.py
@@ -1,13 +1,21 @@
 import discord
+import logging
+
+logger = logging.getLogger("app")
 
 def help_title_card():
+
+    logger.info("Sending help")
+
     embed = discord.Embed(title='Help Info', color=0xffff72)
 
     embed.add_field(
         name='How to use commands:',
-        value='![command] [option1 option2 ...]',
+        value='`![command] [arg1 arg2 ...]`',
         inline=False
     )
+
+    embed.set_footer(text='For more details:\n!help [command]')
 
     return embed
 
@@ -24,8 +32,8 @@ def embedded_help_command(command):
         args='No Args'
 
     embed.add_field(
-        # name=f"{command}\n",
-        name='__Options:__',
+        # name=f"{command}",
+        name='__Arguments:__',
         value=args,
         inline=False
     )

--- a/utils/messages.py
+++ b/utils/messages.py
@@ -14,8 +14,6 @@ def help_title_card():
         name="How to use commands:", value="`![command] [arg1 arg2 ...]`", inline=False
     )
 
-    # embed.set_footer(text='For more details:\n!help [command]')
-
     return embed
 
 

--- a/utils/messages.py
+++ b/utils/messages.py
@@ -31,7 +31,8 @@ def embedded_matchday_results(matchday, season, matchdays, matchdate):
     Returns:
         embed message object
     """
-
+    pre_season = int(season)-1
+    season = str(pre_season) +'\/'+ season
     title = "Matchday " + matchday + "  " + season
     embed = discord.Embed(title=title, description=matchdate, color=0xDC052D)
     for match in matchdays[matchdate]:

--- a/utils/messages.py
+++ b/utils/messages.py
@@ -1,5 +1,37 @@
 import discord
 
+def help_title_card():
+    embed = discord.Embed(title='Help Info', color=0xffff72)
+
+    embed.add_field(
+        name='How to use commands:',
+        value='![command] [option1 option2 ...]',
+        inline=False
+    )
+
+    return embed
+
+def embedded_help_command(command):
+    embed = discord.Embed(title='`'+command.name+'`', color=0xffff72)
+    args = '> '
+    try:
+        for arg_tuple in command.usage:
+            if command.usage.index(arg_tuple) == len(command.usage)-1:
+                args += arg_tuple[0] +': '+ arg_tuple[1] +'\n'
+            else:
+                args += arg_tuple[0] +': '+ arg_tuple[1] +'\n > '
+    except TypeError:
+        args='No Args'
+
+    embed.add_field(
+        # name=f"{command}\n",
+        name='__Options:__',
+        value=args,
+        inline=False
+    )
+
+    return embed
+
 
 def embedded_stats(title, **stats):
     """Build embedded message with generic statistics

--- a/utils/messages.py
+++ b/utils/messages.py
@@ -3,39 +3,39 @@ import logging
 
 logger = logging.getLogger("app")
 
+
 def help_title_card():
 
     logger.info("Sending help")
 
-    embed = discord.Embed(title='Help Info', color=0xffff72)
+    embed = discord.Embed(title="Help Info", color=0xFFFF72)
 
     embed.add_field(
-        name='How to use commands:',
-        value='`![command] [arg1 arg2 ...]`',
-        inline=False
+        name="How to use commands:", value="`![command] [arg1 arg2 ...]`", inline=False
     )
 
     # embed.set_footer(text='For more details:\n!help [command]')
 
     return embed
 
+
 def embedded_help_command(command):
-    embed = discord.Embed(title='`'+command.name+'`', color=0xffff72)
-    args = '> '
+    embed = discord.Embed(title="`" + command.name + "`", color=0xFFFF72)
+    args = "> "
     try:
         for arg_tuple in command.usage:
-            if command.usage.index(arg_tuple) == len(command.usage)-1:
-                args += arg_tuple[0] +': '+ arg_tuple[1] +'\n'
+            if command.usage.index(arg_tuple) == len(command.usage) - 1:
+                args += arg_tuple[0] + ": " + arg_tuple[1] + "\n"
             else:
-                args += arg_tuple[0] +': '+ arg_tuple[1] +'\n > '
+                args += arg_tuple[0] + ": " + arg_tuple[1] + "\n > "
     except TypeError:
-        args='No Args'
+        args = "No Args"
 
     embed.add_field(
         # name=f"{command}",
-        name='__Arguments:__',
+        name="__Arguments:__",
         value=args,
-        inline=False
+        inline=False,
     )
 
     return embed
@@ -71,8 +71,8 @@ def embedded_matchday_results(matchday, season, matchdays, matchdate):
     Returns:
         embed message object
     """
-    pre_season = int(season)-1
-    season = str(pre_season) +'\/'+ season
+    pre_season = int(season) - 1
+    season = str(pre_season) + "\/" + season
     title = "Matchday " + matchday + "  " + season
     embed = discord.Embed(title=title, description=matchdate, color=0xDC052D)
     for match in matchdays[matchdate]:

--- a/utils/messages.py
+++ b/utils/messages.py
@@ -15,7 +15,7 @@ def help_title_card():
         inline=False
     )
 
-    embed.set_footer(text='For more details:\n!help [command]')
+    # embed.set_footer(text='For more details:\n!help [command]')
 
     return embed
 


### PR DESCRIPTION
# Description
- replaced default help command with custom help command that uses the parameters of the command decorator.
- default help command used doc string, which is more developer focused.

Resolves #29 

## Special Notes
- did not complete help command for individual commands (eg. !help blurb); add this to backlog

## Suggested Version Bump
- [ ] Major
- [x] Minor
- [ ] Patch

# Checklist:
- [x] I have run `black .`
- [ ] I have made corresponding changes to the documentation - N/A
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added logging
